### PR TITLE
Added scroll-triggered fade-in animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     </nav>
   </header>
   <!-- Hero Section -->
-  <section class="hero-section">
+  <section class="hero-section fade-in">
     <div class="container">
       <div class="row align-items-center">
         <div class="col-lg-6">
@@ -98,7 +98,7 @@
   </section>
 
   <!-- Our Story Section -->
-  <section class="story-section py-5">
+  <section class="story-section py-5 fade-in">
     <div class="container">
       <div class="row">
         <div class="col-12">
@@ -123,7 +123,7 @@
   </section>
 
   <!-- Hot Items Section -->
-  <section class="hot-items-section py-5">
+  <section class="hot-items-section py-5 fade-in">
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title text-white">
@@ -184,7 +184,7 @@
   <script src="theme.js"></script>
 </body>
   <!-- Enhanced Footer -->
-  <footer class="footer-section">
+  <footer class="footer-section fade-in">
     <div class="container">
       <div class="row g-4">
         <!-- Brand Info -->

--- a/styles.css
+++ b/styles.css
@@ -1091,3 +1091,16 @@ html {
 .container {
     max-width: 1200px;
 }
+
+/* Scroll Fade-in Animation */
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: all 1s ease-out;
+}
+ 
+.fade-in.appear {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/theme.js
+++ b/theme.js
@@ -47,3 +47,25 @@ document.addEventListener('DOMContentLoaded', function() {
         localStorage.setItem('theme', newTheme);
     });
 });
+
+// Scroll Fade-in Animation
+document.addEventListener("DOMContentLoaded", () => {
+  const faders = document.querySelectorAll(".fade-in");
+
+  const appearOptions = {
+    threshold: 0.2, 
+  };
+
+  const appearOnScroll = new IntersectionObserver((entries, observer) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add("appear");
+        observer.unobserve(entry.target);
+      }
+    });
+  }, appearOptions);
+
+  faders.forEach(fader => {
+    appearOnScroll.observe(fader);
+  });
+});


### PR DESCRIPTION
This PR introduces fade-in animations that trigger as the user scrolls down the page. It enhances the user experience by making the transitions smoother and more engaging.
Fixes: #16 
Changes Made:

Added CSS classes (.fade-in + .appear) in styles.css
Implemented IntersectionObserver in theme.js to trigger animations on scroll
Applied .fade-in class to key sections (hero, story, hot-items, and footer)

How It Works:

Elements start hidden (opacity: 0, slight downward offset).
As the user scrolls, once 20% of the element is visible, the animation plays (opacity: 1, slide-up).
Animation plays only once per element for performance and UX.

Preview:
On scroll → sections fade and slide into view smoothly.
[fix-2.webm](https://github.com/user-attachments/assets/c03418b8-2e4e-4dff-a467-2ec53bf85795)


Additional Notes:
Please consider this PR for Hacktoberfest 2025 🚀
