### PR TITLE
Added an animated counters for review stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,43 +196,44 @@
       
       <!-- Review Stats -->
       <div class="review-stats text-center mb-5">
-        <div class="row g-4">
-          <div class="col-md-4">
-            <div class="stat-card">
-              <div class="stat-icon mb-3">
-                <i class="fas fa-star text-warning fa-2x"></i>
-              </div>
-              <h3 class="text-warning mb-2" id="averageRating">4.8</h3>
-              <div class="stars mb-3">
-                <i class="fas fa-star text-warning"></i>
-                <i class="fas fa-star text-warning"></i>
-                <i class="fas fa-star text-warning"></i>
-                <i class="fas fa-star text-warning"></i>
-                <i class="fas fa-star text-warning"></i>
-              </div>
-              <p class="text-white-50 mb-0">Average Rating</p>
-            </div>
-          </div>
-          <div class="col-md-4">
-            <div class="stat-card">
-              <div class="stat-icon mb-3">
-                <i class="fas fa-comments text-primary fa-2x"></i>
-              </div>
-              <h3 class="text-primary mb-2" id="totalReviews">1,247</h3>
-              <p class="text-white-50 mb-0">Total Reviews</p>
-            </div>
-          </div>
-          <div class="col-md-4">
-            <div class="stat-card">
-              <div class="stat-icon mb-3">
-                <i class="fas fa-thumbs-up text-success fa-2x"></i>
-              </div>
-              <h3 class="text-success mb-2" id="satisfactionRate">96%</h3>
-              <p class="text-white-50 mb-0">Satisfied Customers</p>
-            </div>
-          </div>
+     <div class="review-stats text-center mb-5">
+  <div class="row g-4">
+    <div class="col-md-4">
+      <div class="stat-card">
+        <div class="stat-icon mb-3">
+          <i class="fas fa-star text-warning fa-2x"></i>
         </div>
+        <h3 class="text-warning mb-2" id="averageRating" data-target="4.8">0</h3>
+        <div class="stars mb-3">
+          <i class="fas fa-star text-warning"></i>
+          <i class="fas fa-star text-warning"></i>
+          <i class="fas fa-star text-warning"></i>
+          <i class="fas fa-star text-warning"></i>
+          <i class="fas fa-star text-warning"></i>
+        </div>
+        <p class="text-white-50 mb-0">Average Rating</p>
       </div>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <div class="stat-icon mb-3">
+          <i class="fas fa-comments text-primary fa-2x"></i>
+        </div>
+        <h3 class="text-primary mb-2" id="totalReviews" data-target="1247">0</h3>
+        <p class="text-white-50 mb-0">Total Reviews</p>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <div class="stat-icon mb-3">
+          <i class="fas fa-thumbs-up text-success fa-2x"></i>
+        </div>
+        <h3 class="text-success mb-2" id="satisfactionRate" data-target="96">0%</h3>
+        <p class="text-white-50 mb-0">Satisfied Customers</p>
+      </div>
+    </div>
+  </div>
+</div>
 
       <!-- Reviews Marquee -->
       <div class="reviews-carousel-container">

--- a/theme.js
+++ b/theme.js
@@ -50,3 +50,46 @@ document.addEventListener("DOMContentLoaded", () => {
     }, appearOptions);
     faders.forEach(fader => appearOnScroll.observe(fader));
 });
+
+function animateCounter(el, duration, startTime) {
+  const target = parseFloat(el.getAttribute('data-target'));
+
+  function update(timestamp) {
+    if (!startTime) startTime = timestamp;
+    const progress = Math.min((timestamp - startTime) / duration, 1);
+    let value = target * progress;
+
+    if (el.id === 'satisfactionRate') {
+      el.textContent = Math.floor(value) + '%';
+    } else if (el.id === 'averageRating') {
+      el.textContent = value.toFixed(1);
+    } else {
+      el.textContent = Math.floor(value);
+    }
+
+    if (progress < 1) {
+      requestAnimationFrame(update);
+    } else {
+      // This ensures that it ends exactly at target
+      if (el.id === 'satisfactionRate') el.textContent = target + '%';
+      else if (el.id === 'averageRating') el.textContent = target.toFixed(1);
+      else el.textContent = target;
+    }
+  }
+
+  requestAnimationFrame(update);
+}
+
+function isInViewport(el) {
+  const rect = el.getBoundingClientRect();
+  return rect.top <= window.innerHeight && rect.bottom >= 0;
+}
+
+let animated = false;
+window.addEventListener('scroll', () => {
+  if (!animated && isInViewport(document.querySelector('.review-stats'))) {
+    animated = true;
+    const duration = 800; // 0.8 seconds
+    document.querySelectorAll('.review-stats h3').forEach(el => animateCounter(el, duration));
+  }
+});


### PR DESCRIPTION
This PR adds smooth, synchronized counter animations for the review stats section:
Average Rating
Total Reviews
Satisfied Customers

Changes:
Numbers now count up from 0 → target when the section scrolls into view.
All three counters finish at the same time.
Preserves icons, stars, and % formatting exactly as before.

This makes the stats section more engaging and visually appealing while keeping the original layout intact.
[3.webm](https://github.com/user-attachments/assets/f735faaa-d762-485c-ac0f-f0170b39fcd3)

Closes: #25 
Hacktoberfest 2025:
I’m submitting this as part of Hacktoberfest 2025