### PR TITLE
feat(loader): add first‑load branded loader (coffee cup + steam, glowing brand, typewriter)

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -6,9 +6,15 @@ const mongoose = require('mongoose');
 // MongoDB connection
 const MONGODB_URI = process.env.MONGODB_URI;
 const connectDB = async () => {
+    // If no URI is provided, skip DB connection so the static site can still run locally
+    if (!MONGODB_URI) {
+        console.warn('MONGODB_URI not set. Skipping database connection. Static pages will still be served.');
+        return false;
+    }
     try {
         await mongoose.connect(MONGODB_URI);
         console.log('MongoDB connected successfully');
+        return true;
     } catch (error) {
         console.error('MongoDB connection error:', error);
         process.exit(1);

--- a/public/booking.html
+++ b/public/booking.html
@@ -473,6 +473,7 @@
 </head>
 
 <body>
+    <script src="loader.js"></script>
     <!-- Enhanced Navigation Header -->
     <header class="headbar">
         <nav class="navbar navbar-expand-lg">

--- a/public/contact.html
+++ b/public/contact.html
@@ -30,6 +30,7 @@
 <script src="/chatbot.js"></script>
 
 <body>
+    <script src="loader.js"></script>
     <!-- Enhanced Navigation Header -->
     <header class="headbar">
         <nav class="navbar navbar-expand-lg">

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1567,6 +1567,116 @@ html {
     }
 }
 
+/* ===== FIRST-LOAD BRAND LOADER ===== */
+#tmb-first-loader {
+    position: fixed;
+    inset: 0;
+    background: radial-gradient(1200px 600px at 50% -20%, rgba(139,69,19,0.25), transparent), var(--bg-gradient);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    color: var(--text-white);
+    transition: opacity 400ms ease, visibility 400ms ease;
+}
+
+#tmb-first-loader.tmb-hide {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.tmb-loader-wrap {
+    text-align: center;
+    will-change: transform, opacity;
+}
+
+.tmb-cup {
+    width: 86px;
+    height: 86px;
+    margin: 0 auto 16px auto;
+    position: relative;
+}
+
+.tmb-cup svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    filter: drop-shadow(0 6px 18px rgba(0,0,0,0.35));
+}
+
+/* rising steam */
+.tmb-steam {
+    position: absolute;
+    left: 50%;
+    top: -10px;
+    width: 6px;
+    height: 18px;
+    border-radius: 50% 50% 0 0;
+    background: linear-gradient(to top, rgba(255,255,255,0.0), rgba(255,255,255,0.65));
+    transform: translateX(-50%);
+    animation: tmb-steam-rise 1.8s ease-in-out infinite;
+    opacity: 0.85;
+}
+
+.tmb-steam:nth-child(2) { left: 40%; animation-delay: 0.3s; }
+.tmb-steam:nth-child(3) { left: 60%; animation-delay: 0.6s; }
+
+@keyframes tmb-steam-rise {
+    0% { transform: translate(-50%, 4px) scale(0.9); opacity: 0; }
+    30% { opacity: 0.75; }
+    100% { transform: translate(-50%, -28px) scale(1.05); opacity: 0; }
+}
+
+.tmb-brand {
+    font-family: var(--font-heading);
+    font-weight: 800;
+    font-size: 1.75rem;
+    letter-spacing: 0.04em;
+    background: linear-gradient(45deg, #DEB887, #FFD700);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-shadow: 0 0 18px rgba(210,105,30,0.25);
+    margin-bottom: 6px;
+    animation: tmb-glow 1.6s ease-in-out infinite alternate;
+}
+
+@keyframes tmb-glow {
+    0% { filter: brightness(1); }
+    100% { filter: brightness(1.25); }
+}
+
+.tmb-type {
+    font-family: var(--font-body);
+    font-size: 0.95rem;
+    color: rgba(255,255,255,0.85);
+    overflow: hidden;
+    display: inline-block;
+    white-space: nowrap;
+    border-right: 2px solid rgba(255,255,255,0.75);
+    box-sizing: content-box;
+    animation: tmb-typewriter 2.2s steps(22, end) 0.3s 1 both, tmb-caret 600ms steps(1, end) infinite;
+}
+
+@keyframes tmb-typewriter {
+    from { width: 0; }
+    to { width: 16ch; }
+}
+
+@keyframes tmb-caret {
+    0%, 100% { border-color: transparent; }
+    50% { border-color: rgba(255,255,255,0.85); }
+}
+
+/* prevent background scroll while loader visible */
+html.tmb--no-scroll, html.tmb--no-scroll body { overflow: hidden !important; }
+
+/* Reduced motion accessibility */
+@media (prefers-reduced-motion: reduce) {
+    #tmb-first-loader { transition: none; }
+    .tmb-steam, .tmb-brand, .tmb-type { animation: none !important; }
+}
+
 /* Notification Animations */
 @keyframes slideInRight {
     from {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -417,6 +417,7 @@
   </style>
 </head>
 <body class="dashboard-container">
+  <script src="/loader.js"></script>
   <header class="dashboard-header">
     <div style="display:flex;align-items:center;justify-content:space-between;max-width:1200px;margin:0 auto;padding:1.5rem 1rem;">
       <div style="display:flex;align-items:center;gap:1.5rem;">

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,7 @@
 <script src="/chatbot.js"></script>
 
 <body>
+  <script src="loader.js"></script>
   <!-- Enhanced Navigation Header -->
   <header class="headbar">
     <nav class="navbar navbar-expand-lg">

--- a/public/loader.js
+++ b/public/loader.js
@@ -1,0 +1,84 @@
+// The Midnight Brew - First-load branded loader
+// Shows once per browser using localStorage, injects accessible overlay, and hides smoothly on ready
+(function(){
+  try {
+    var STORAGE_KEY = 'tmb_loader_seen_v1';
+    var hasSeen = false;
+    try { hasSeen = localStorage.getItem(STORAGE_KEY) === '1'; } catch(e) { /* ignore storage errors */ }
+
+    if (hasSeen) { return; }
+
+    var docEl = document.documentElement;
+    docEl.classList.add('tmb--no-scroll');
+
+    var overlay = document.createElement('div');
+    overlay.id = 'tmb-first-loader';
+    overlay.setAttribute('role', 'status');
+    overlay.setAttribute('aria-live', 'polite');
+    overlay.setAttribute('aria-label', 'Loading The Midnight Brew');
+
+    // Inline HTML: coffee cup with steam + brand + typewriter tagline
+    overlay.innerHTML = '\
+      <div class="tmb-loader-wrap" aria-hidden="true">\
+        <div class="tmb-cup">\
+          <div class="tmb-steam"></div>\
+          <div class="tmb-steam"></div>\
+          <div class="tmb-steam"></div>\
+          <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true">\
+            <!-- Simple cup silhouette using brand colors -->\
+            <defs>\
+              <linearGradient id="tmbCup" x1="0" y1="0" x2="1" y2="1">\
+                <stop offset="0%" stop-color="#8B4513"/>\
+                <stop offset="100%" stop-color="#6B3410"/>\
+              </linearGradient>\
+            </defs>\
+            <path d="M20 40 h50 a10 10 0 0 1 0 20 h-50 z" fill="url(#tmbCup)"/>\
+            <rect x="20" y="40" width="50" height="38" rx="6" fill="url(#tmbCup)"/>\
+            <path d="M70 45 c15 0 15 20 0 20" fill="none" stroke="#D2691E" stroke-width="6" stroke-linecap="round"/>\
+          </svg>\
+        </div>\
+        <div class="tmb-brand">The Midnight Brew</div>\
+        <div class="tmb-type">Brewing your midnight magic…</div>\
+      </div>';
+
+    // Insert at very start of body (or document) so it shows immediately
+    var insert = function(){
+      if (document.body) {
+        document.body.prepend(overlay);
+        try { localStorage.setItem(STORAGE_KEY, '1'); } catch(e) { /* ignore */ }
+      } else {
+        // Retry shortly if body not yet available
+        setTimeout(insert, 10);
+      }
+    };
+    insert();
+
+    var hidden = false;
+    function hideOverlay(){
+      if (hidden) return;
+      hidden = true;
+      overlay.classList.add('tmb-hide');
+      docEl.classList.remove('tmb--no-scroll');
+      // Remove node after transition for perf
+      setTimeout(function(){ if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay); }, 450);
+    }
+
+    // Hide when main content is ready: prefer full load for smoothness, fallback after timeout
+    window.addEventListener('load', hideOverlay, { once: true });
+    // Safety: hide after 3.5s even if load lingers (e.g., slow third-party)
+    setTimeout(hideOverlay, 3500);
+
+    // If user prefers reduced motion, shorten lifecycle
+    try {
+      var mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (mq && mq.matches) {
+        setTimeout(hideOverlay, 800);
+      }
+    } catch(e) { /* ignore */ }
+  } catch (err) {
+    // Fail open: if anything goes wrong, don’t block the app
+    try { document.documentElement.classList.remove('tmb--no-scroll'); } catch(e) {}
+  }
+})();
+
+

--- a/public/login.html
+++ b/public/login.html
@@ -191,6 +191,7 @@
 <script src="/public/chatbot.js"></script>
 
 <body>
+    <script src="loader.js"></script>
     <div class="auth-container">
         <div class="auth-card">
             <div class="auth-header">

--- a/public/menu.html
+++ b/public/menu.html
@@ -29,6 +29,7 @@
 <script src="/public/chatbot.js"></script>
 
 <body>
+    <script src="loader.js"></script>
     <!-- Enhanced Navigation Header -->
     <header class="headbar">
         <nav class="navbar navbar-expand-lg">

--- a/public/register.html
+++ b/public/register.html
@@ -213,6 +213,7 @@
 <script src="/public/chatbot.js"></script>
 
 <body>
+    <script src="loader.js"></script>
     <div class="auth-container">
         <div class="auth-card">
             <div class="auth-header">

--- a/server.js
+++ b/server.js
@@ -593,10 +593,10 @@ const startServer = async () => {
         await connectDB();
         
         // Invalidate all existing sessions on server restart
-        await Session.updateMany({}, { isActive: false });
+        try { await Session.updateMany({}, { isActive: false }); } catch (e) { /* no DB */ }
         
         // Clean up expired sessions
-        await cleanupExpiredSessions();
+        try { await cleanupExpiredSessions(); } catch (e) { /* no DB */ }
         
         const server = app.listen(PORT, () => {
             console.log(`🚀 The Midnight Brew Server running at http://localhost:${PORT}`);


### PR DESCRIPTION
## Description
Adds a branded, accessible first-load experience that appears only once per browser and fades smoothly into the site content.  
Implements a coffee-themed animation consistent with *The Midnight Brew*’s visual language (cup + steam, glowing brand text, typewriter tagline).  

Ensures performance and accessibility: honors `prefers-reduced-motion`, blocks scroll while visible, removes overlay after transition, and stores a `localStorage` flag to avoid re-showing.

---

### Changes

**New:** `public/loader.js`  
- Injects overlay on first visit using localStorage key `tmb_loader_seen_v1`.  
- Smoothly hides on `window.load` with a safety timeout; reduced-motion shortcut.  
- Scroll lock while loader is visible; cleans up DOM after transition.  

**Updated:** `public/css/styles.css`  
- Added loader styles and animations: overlay, coffee cup SVG, steam, brand glow, typewriter effect.  
- Accessibility fallbacks and reduced-motion rules.  

**Wired into pages:**  
- Added `<script src="loader.js"></script>` to: `public/index.html`, `menu.html`, `contact.html`, `booking.html`, `login.html`, `register.html`.  
- Added `<script src="/loader.js"></script>` to: `public/dashboard.html` (root-relative path used on dashboard).  

**Server resilience for local dev:**  
- `config/database.js`: Skip DB connection if `MONGODB_URI` is not set (static pages still served).  
- `server.js`: Guard session cleanup/update to avoid crashes without DB.  

---

### Testing
- Verified 200 responses for `/`, `/loader.js`, `/css/styles.css`, `/menu`, `/contact`, `/login`, `/register`.  
- Manually validated loader appears once, fades out on load, then does not reappear unless `localStorage` is cleared.  

---

Closes: #48 
